### PR TITLE
Potential fix for code scanning alert no. 3: Arbitrary file access during archive extraction ("Zip Slip")

### DIFF
--- a/pkg/api/system.go
+++ b/pkg/api/system.go
@@ -1161,7 +1161,11 @@ func extractZipFile(file *zip.File, destDir string, junkPaths bool, overwrite bo
 		filePath = filepath.Join(destDir, filepath.Base(file.Name))
 	} else {
 		// Use the full path structure
-		filePath = filepath.Join(destDir, file.Name)
+		cleanPath := filepath.Clean(filepath.Join(destDir, file.Name))
+		if !strings.HasPrefix(cleanPath, filepath.Clean(destDir)+string(os.PathSeparator)) {
+			return fmt.Errorf("invalid file path: %s", file.Name)
+		}
+		filePath = cleanPath
 	}
 
 	// Check if this is a directory


### PR DESCRIPTION
Potential fix for [https://github.com/pi-apps-go/pi-apps/security/code-scanning/3](https://github.com/pi-apps-go/pi-apps/security/code-scanning/3)

To fix the issue, the code should validate the paths of files extracted from the zip archive to ensure they do not contain directory traversal elements (`..`) or attempt to write files outside the intended destination directory. The best approach is to:
1. Use `filepath.Clean` to normalize the path and remove any redundant or malicious elements.
2. Check that the resulting path is within the intended destination directory using `filepath.HasPrefix` or equivalent logic.
3. Reject or skip files with invalid paths.

The changes should be made in the `extractZipFile` function in `pkg/api/system.go`, where the `filePath` is constructed and used.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
