### PR TITLE
Potential fix for code scanning alert no. 3: Arbitrary file access during archive extraction ("Zip Slip")

### DIFF
--- a/pkg/api/system.go
+++ b/pkg/api/system.go
@@ -1156,6 +1156,12 @@ func Unzip(zipFile string, destDir string, flags []string) error {
 func extractZipFile(file *zip.File, destDir string, junkPaths bool, overwrite bool, quiet bool) error {
 	// Determine the extraction path
 	var filePath string
+
+	// Check for directory traversal attempts
+	if strings.Contains(file.Name, "..") {
+		return fmt.Errorf("invalid file path: %s (contains '..')", file.Name)
+	}
+
 	if junkPaths {
 		// Just use the filename, without directory structure
 		filePath = filepath.Join(destDir, filepath.Base(file.Name))


### PR DESCRIPTION
Potential fix for [https://github.com/pi-apps-go/pi-apps/security/code-scanning/3](https://github.com/pi-apps-go/pi-apps/security/code-scanning/3)

To fix the issue, we will add an explicit check to ensure that the `file.Name` field from the zip archive does not contain any `..` elements. This will prevent directory traversal attacks by ensuring that no file paths attempt to escape the intended destination directory. The fix will involve modifying the `extractZipFile` function to include this validation step before constructing the file path.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
